### PR TITLE
Correcting RandRootboundTree function name and move 12 in Markov

### DIFF
--- a/core/Markov.m
+++ b/core/Markov.m
@@ -138,10 +138,10 @@ for t=1:(mcmc.subsample)
         if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==12
         update='Rescale top tree';
-        if model.prior.isclade
-            %keyboard;
-            [nstate,U,TOPOLOGY,logq,OK]=RscaleTopTree(state,model.prior,mcmc.update.del,mcmc.update.deldel);
+        if ~model.prior.isclade
+            error('Move 12 should not be selected if no clades');
         end
+        [nstate,U,TOPOLOGY,logq,OK]=RscaleTopTree(state,model.prior,mcmc.update.del,mcmc.update.deldel);
         % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
         if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==13

--- a/core/RandRootboundTree.m
+++ b/core/RandRootboundTree.m
@@ -1,4 +1,4 @@
-function s = RandCladeTree(clade,langname, rootmax);
+function s = RandRootboundTree(clade,langname, rootmax)
 % builds a random tree using the coalescent tree building model
 % so that all clades are observed and the times are scaled so that 
 % the age constrains on the clades are observed


### PR DESCRIPTION
In practice, RandRootboundTree is not called by any other functions and the issue corrected in move 12 (no clade so move ignored by logq changed anyway) should never arise.