### PR TITLE
Bug fix for d082fe2 to avoid changing rho as part of Rscale move or computing its prior

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ This is important when specifying clade constraints. We return to this in the se
 
 ## Notes
 
-If catastrophes are included and:
-* The option to fix the catastrophe rate, _rho_, at a value is selected, then the number of catastrophes on each branch of the tree _a priori_ is a Poisson random variable
-* The option to allow _rho_ to vary is selected, then we integrate _rho_ out analytically and the number of catastrophes on each branch is a Negative Binomial random variable.
-* When starting runs from a tree in the output file, say, the initial catastrophe tree will be different as catastrophe locations are currently not stored in an output file. See the section 'Bayes factors using the posterior predictive' below for more details.
+If catastrophes are included in the Stochastic Dollo model and the catastrophe rate `rho` is
+* Fixed, then the number of catastrophes a branch of length `t` is `Poisson(rho t)`
+* Allowed to vary, then we integrate `rho` out analytically and the number of catastrophes on each branch is a Negative Binomial random variable.
+
+When accounting for lateral transfer, we require the catastrophe locations so include their density in the above calculations.
+
+* When starting runs from a tree in the output file, say, the initial catastrophe tree will be different as catastrophe locations are not currently stored in the output, only their branch counts. See the below section 'Bayes factors using the posterior predictive' for more details.
 
 MCMC moves on _rho_ have been disabled as a consequence. See Chapter 2 of [Kelly (2016)][4] or the supplement of [Kelly and Nicholls (2017)][5] for further details on this calculation
 

--- a/core/LogPriorParm.m
+++ b/core/LogPriorParm.m
@@ -4,7 +4,7 @@ function res=LogPriorParm(state,nstate)
 % the priors for the parameters mu, lambda, nu, kappa and rho in state and
 % nstate.
 
-global VARYNU VARYLAMBDA VARYRHO VARYBETA BORROWING
+global VARYNU VARYLAMBDA VARYBETA % BORROWING
 
 %if BORROWING
     % We can't use a prior of 1/mu as the posterior is unbounded so we use
@@ -14,7 +14,8 @@ global VARYNU VARYLAMBDA VARYRHO VARYBETA BORROWING
 %    res=log(state.mu)-log(nstate.mu);
 %end
 
-if VARYRHO, res=res+LogRhoPrior(nstate.rho)-LogRhoPrior(state.rho);end
+% LJK 06/21, if VARYRHO then it's integrated out analytically, fixed otherwise
+% if VARYRHO, res=res+LogRhoPrior(nstate.rho)-LogRhoPrior(state.rho);end
 if VARYLAMBDA, res=res+log(state.lambda)-log(nstate.lambda); end
 if VARYNU, res=res+log(state.nu)-log(nstate.nu); end
 

--- a/core/Rscale.m
+++ b/core/Rscale.m
@@ -1,6 +1,6 @@
 function [nstate,U,TOPOLOGY,OK,logq]=Rscale(state,variation)
 
-global VARYMU VARYRHO VARYBETA
+global VARYMU VARYBETA
 
 s=state.tree;
 nstate=state;
@@ -32,10 +32,11 @@ if VARYMU
    nstate.mu=state.mu/variation;
    logq=logq-log(variation);
 end
-if VARYRHO
-    nstate.rho=state.rho/variation;
-    logq=logq-log(variation);
-end
+% LJK 06/21, rho either integrated out or constant
+% if VARYRHO
+%     nstate.rho=state.rho/variation;
+%     logq=logq-log(variation);
+% end
 if VARYBETA
     nstate.beta = state.beta / variation;
     logq=logq-log(variation);


### PR DESCRIPTION
Although direct moves on rho `were` disabled, `Rscale` could still change `rho` which caused a difference in priors when `VARYRHO` was false. This has now been rectified so `rho` is either integrated out analytically or fixed at a particular value.