### PR TITLE
Jacobian terms for catastrophes with/without locations

### DIFF
--- a/borrowing/catastropheScalingFactorCheck.m
+++ b/borrowing/catastropheScalingFactorCheck.m
@@ -1,0 +1,15 @@
+function catastropheScalingFactorCheck(state, nstate, prior)
+    % Checking that catastrophe locations are properly accounted for    
+    global BORROWING;
+    oldBORROWING = BORROWING;
+    BORROWING = 0;
+    csf = catastropheScalingFactor(state, nstate);
+    n1 = - csf + LogPrior(prior, nstate) - LogPrior(prior, state);
+    BORROWING = 1;
+    n2 = LogPrior(prior, nstate) - LogPrior(prior, state);
+    
+    if abs(csf) > 1e-10 && abs(n1 - n2) > 1e-10
+        keyboard;
+    end
+    BORROWING = oldBORROWING;
+end

--- a/core/Markov.m
+++ b/core/Markov.m
@@ -32,24 +32,18 @@ for t=1:(mcmc.subsample)
         update='RW node time between parent time and oldest child time';
         [i,newage,logq]=Schoose(state);
         [nstate,U,TOPOLOGY]=Supdate(state,i,newage);
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==2
         update='Exchange nearest neighbours';
         [i,j,iP,jP,logq,OK]=Echoose(state,NARROW,model.prior);
         if OK
             [nstate,U,TOPOLOGY]=Eupdate(state,i,j,iP,jP);
         end
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==3
         update='reconnect two edges randomly chosen across tree';
         [i,j,iP,jP,logq]=Echoose(state,WIDE,model.prior);
         if OK
             [nstate,U,TOPOLOGY]=Eupdate(state,i,j,iP,jP);
         end
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==4
         update='Reconnect an edge into a nearby edge';
         [i,j,k,newage,logq]=Bchoose(state,NARROW,mcmc.update.theta,model.prior);
@@ -57,8 +51,6 @@ for t=1:(mcmc.subsample)
         if OK
             [nstate,U,TOPOLOGY]=Bupdate(state,i,j,k,newage);
         end
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==5
         update='Reconnect an edge into an edge chosen UAR over the tree';
         [i,j,k,newage,logq]=Bchoose(state,WIDE,mcmc.update.theta,model.prior);
@@ -66,19 +58,13 @@ for t=1:(mcmc.subsample)
         if OK
             [nstate,U,TOPOLOGY]=Bupdate(state,i,j,k,newage);
         end
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==6
         update='Rescale whole tree';
         variation=mcmc.update.del+rand*mcmc.update.deldel;
         [nstate,U,TOPOLOGY,OK,logq]=Rscale(state,variation);
-        % Luke 11/06/2021 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==7
         update='Rescale randomly chosen subtree';
         [nstate,U,TOPOLOGY,logq,OK]=RscaleSubTree(state,mcmc.update.del,mcmc.update.deldel);
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==8
         update='Vary mu';
         if ~VARYMU, disp('vary mu ?'); keyboard;pause; end
@@ -129,16 +115,12 @@ for t=1:(mcmc.subsample)
                 OK=0;
             end
         end
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==12
         update='Rescale top tree';
         if ~model.prior.isclade
             error('Move 12 should not be selected if no clades');
         end
         [nstate,U,TOPOLOGY,logq,OK]=RscaleTopTree(state,model.prior,mcmc.update.del,mcmc.update.deldel);
-        % Luke 11/05/2016 "Resampling" catastrophes when borrowing.
-        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==13
         update='Add a catastrophe';
         [nstate, U, OK, logq]=AddCat(state);
@@ -230,6 +212,11 @@ for t=1:(mcmc.subsample)
         TOPOLOGY = 0;
         U = state.nodes;
     end % End of move section.
+
+    % Contribution to logq from catastrophe locations
+    if OK && BORROWING && ismember(MV, [1:7, 11:12])
+        logq = logq + catastropheScalingFactor(state, nstate);
+    end
 
     if OK && model.prior.isclade
         if TOPOLOGY

--- a/core/Markov.m
+++ b/core/Markov.m
@@ -72,13 +72,8 @@ for t=1:(mcmc.subsample)
         update='Rescale whole tree';
         variation=mcmc.update.del+rand*mcmc.update.deldel;
         [nstate,U,TOPOLOGY,OK,logq]=Rscale(state,variation);
-%         if OK
-%             if VARYMU
-%                 logq=(state.NS-4)*log(variation);
-%             else
-%                 logq=(state.NS-3)*log(variation);
-%             end
-%         end
+        % Luke 11/06/2021 "Resampling" catastrophes when borrowing.
+        if OK && BORROWING; logq = logq + catastropheScalingFactor(state, nstate); end
     elseif MV==7
         update='Rescale randomly chosen subtree';
         [nstate,U,TOPOLOGY,logq,OK]=RscaleSubTree(state,mcmc.update.del,mcmc.update.deldel);

--- a/core/Rscale.m
+++ b/core/Rscale.m
@@ -25,8 +25,10 @@ for k=state.leaves
    end
 end
 
-logq=(state.NS+state.ncat-3)*log(variation);
-%logq=0; %TODO check this RJR 19/04/07
+% LJK 06/21 We do not include catastrophe locations in SD Jacobian but
+% separately account for them in SDLT by borrowing/catastropheScalingFactor
+% logq=(state.NS+state.ncat-3)*log(variation);
+logq = (state.NS - 3) * log(variation);
 
 if VARYMU
    nstate.mu=state.mu/variation;


### PR DESCRIPTION
Rscale had a Jacobian term for catastrophe locations when we were ignoring (SD) and accounting for them (SDLT). This has now been fixed, and with the exception of direct moves on catastrophes themselves, locations are all accounted for by borrowing/catastropheScalingFactor.

In practice, when ignoring locations there is an extra term in the corresponding ratio of priors equivalent to the catastropheScalingFactor when we account for locations.