### PR TITLE
Kappa random initialisation consistent with GUI

### DIFF
--- a/core/batchTraitLab.m
+++ b/core/batchTraitLab.m
@@ -163,7 +163,7 @@ MIR=0;
 
 if MCT
     if exist('Random_initial_cat_death_prob','var') && Random_initial_cat_death_prob
-        MIK=rand;
+        MIK= 0.25 + 0.75 * rand;
         RMIK=1;
     elseif exist('Initial_cat_death_prob','var')
         MIK=Initial_cat_death_prob;


### PR DESCRIPTION
Previously, batchTraitLab random initialisation did not respect constraints of [0.25, 1] on kappa so initial values below 0.125 were always rejected in scaling moves.