### PR TITLE
Fixing initialisating bug in GUI

### DIFF
--- a/guifiles/startbutt_Callback.m
+++ b/guifiles/startbutt_Callback.m
@@ -90,7 +90,7 @@ if ok
             %chosen a fixed kappa value
             MCMCINITKAPPA=str2double(get(handles.kappavalfixet,'String'));
             VARYKAPPA=0;
-        elseif setmu(2)
+        elseif setkappa(2)
             %specified a starting value to vary kappa from
             MCMCINITKAPPA=str2double(get(handles.kappavalet,'String'));
         else


### PR DESCRIPTION
Line 93 of guifiles/startbutt_Callback was using `setmu(2)` instead of `setkappa(2)` when deciding how to initialise kappa.